### PR TITLE
Readme updates, plus bail out early when the gist fails to fetch

### DIFF
--- a/.github/workflows/spotify-box.yml
+++ b/.github/workflows/spotify-box.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   updateTopTracks:
    runs-on: ubuntu-latest
+   environment: prod
    steps:
      - uses: actions/checkout@v2
      - run: npm install

--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ if the response not return refresh_token, back to step 2 and retry.
 ## 🖥 Project Setup
 
 1. Fork this repo
-2. Go to your fork's `Settings` > `Secrets` > `Add a new secret` for each environment secret (below)
-3. Enable Actions on your fork via the 'Actions' tab
-4. Enable the 'spotify-box' Workflow via the 'Actions' tab
+2. Go to your fork's `Settings` > `Environments` > `New environment` and create an environment called "prod"
+3. Choose your "prod" environment and `Add Secret` for each environment secret (below)
+4. Enable Actions on your fork via the 'Actions' tab
+5. Enable the 'spotify-box' Workflow via the 'Actions' tab
+6. Kick off a workflow run of the 'spotify-box' Workflow via Actions > spotify-box > Run workflow
 
 ## 🤫 Environment Secrets
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ if the response not return refresh_token, back to step 2 and retry.
 
 1. Fork this repo
 2. Go to your fork's `Settings` > `Secrets` > `Add a new secret` for each environment secret (below)
+3. Enable Actions on your fork via the 'Actions' tab
+4. Enable the 'spotify-box' Workflow via the 'Actions' tab
 
 ## 🤫 Environment Secrets
 

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ async function updateTopTracks(json) {
     console.error(
       `spotify-box ran into an issue for getting your gist:\n${error}`
     )
+    return
   }
 
   const tracks = json.items.map(item => ({

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ async function updateTopTracks(json) {
     })
   } catch (error) {
     console.error(
-      `spotify-box ran into an issue for getting your gist:\n${error}`
+      `spotify-box ran into an issue for getting your gist ${gist_id}:\n${error}`
     )
     return
   }


### PR DESCRIPTION
Hi there! I had to take a couple extra steps before this would work to update my gist, so I wanted to document them in the readme in case you want to keep the changes:

- Forks have their Actions disabled, so the person who made the fork needs to reenable Actions + the spotify-box Workflow
- I put my secrets as Environment secrets on my fork, not sure if this was right. But it meant the Workflow didn't have access to the secrets I had added till I specified what environment to use in the Action.
- When the gist fails to fetch, we were continuing on, but that resulted in an error because something was undefined, so I just had it return early.
- I updated the error message to include the gist ID when it fails to fetch, which was helpful for me to see that my secrets weren't getting loaded correctly because my gist ID was coming up blank.
- Unless someone edits a file in their fork, the workflow won't run till you manually run it.