### PR TITLE
fix: action deprecation warnings

### DIFF
--- a/.github/workflows/spotify-box.yml
+++ b/.github/workflows/spotify-box.yml
@@ -10,7 +10,7 @@ jobs:
    runs-on: ubuntu-latest
    environment: prod
    steps:
-     - uses: actions/checkout@v2
+     - uses: actions/checkout@master
      - run: npm install
      - name: Update
        uses: ./

--- a/.github/workflows/spotify-box.yml
+++ b/.github/workflows/spotify-box.yml
@@ -10,7 +10,7 @@ jobs:
    runs-on: ubuntu-latest
    environment: prod
    steps:
-     - uses: actions/checkout@master
+     - uses: actions/checkout@v3
      - run: npm install
      - name: Update
        uses: ./

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ author: izayl
 description: GitHub Action for Update a gist to contain your weekly top tracks on Spotify.
 
 runs:
-  using: node12
+  using: node16
   main: ./index.js
 
 branding:

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ async function updateTopTracks(json) {
   if (!tracks.length) return
 
   const lines = []
-  for (let index = 0; index < Math.min(tracks.length, 10); index++) {
+  for (let index = 0; index < Math.min(tracks.length, 50); index++) {
     let { name, artist } = tracks[index]
     name = truncate(name, 25)
     artist = truncate(artist, 19)

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ async function updateTopTracks(json) {
   if (!tracks.length) return
 
   const lines = []
-  for (let index = 0; index < Math.min(tracks.length, 50); index++) {
+  for (let index = 0; index < Math.min(tracks.length, 10); index++) {
     let { name, artist } = tracks[index]
     name = truncate(name, 25)
     artist = truncate(artist, 19)


### PR DESCRIPTION
Node.js 12 actions are deprecated.

> For more information see:
       https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
       Please update the following actions to use Node.js 16: ./

> https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
       Please update the following actions to use Node.js 16: actions/checkout@v2
       Using version v3, latest or master: actions/checkout#689

This PR fixes issue #12 